### PR TITLE
fix: links to post in RSS feed

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -7,7 +7,7 @@ const get = () => rss({
   description: 'Not causing trouble, not touching anything, fixing the primus',
   site: import.meta.env.SITE,
   items: getBlogPosts().map((post) => ({
-    link: post.frontmatter.slug,
+    link: `posts/${post.frontmatter.slug}`
     title: post.frontmatter.title,
     description: post.frontmatter.description,
     pubDate: post.frontmatter.pubDate

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -7,7 +7,7 @@ const get = () => rss({
   description: 'Not causing trouble, not touching anything, fixing the primus',
   site: import.meta.env.SITE,
   items: getBlogPosts().map((post) => ({
-    link: `posts/${post.frontmatter.slug}`
+    link: `posts/${post.frontmatter.slug}`,
     title: post.frontmatter.title,
     description: post.frontmatter.description,
     pubDate: post.frontmatter.pubDate


### PR DESCRIPTION
Just added the missed `posts/` slug