### PR TITLE
fix: remove deprecated `globEager` usage

### DIFF
--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,7 +1,8 @@
 // TODO: Type it
-const getBlogPosts = () => 
-  Object.values(import.meta.globEager('../pages/posts/*.md'))
-    .sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf())
-    .filter(a => !a.frontmatter.publshed);
+function getBlogPosts () {
+  return Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }))
+  .sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf())
+  .filter(a => !a.frontmatter.publshed);
+};
 
 export { getBlogPosts };


### PR DESCRIPTION
Because it has deprecated now. Replace it with a modern alternative.