### PR TITLE
footer: remove place of employment

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 <footer>
   <hr width='25%'/>
-  <p>An engineer @ <a target='_blank' href='https://readymag.com'>Readymag</a>, a dreamer, a reader.</p>
+  <p>An engineer, a dreamer, a reader.</p>
   <br />
   <span>
     [↗]: <a target='_blank' href='mailto:vlad@esafev.com'>@</a>, <a target='_blank' href='https://are.na/vlad-esafev'>Are.na</a>, <a target='_blank' href='https://github.com/esafev'>GitHub</a>, <a target='_blank' href='https://x.com/vladesafev'>X</a>, <a target='_blank' href='https://esafev.com/rss.xml'>RSS</a>


### PR DESCRIPTION
should be moved to the `/about` page