### PR TITLE
dx: dont call GitHub api while dev

### DIFF
--- a/src/components/LastUpdated.astro
+++ b/src/components/LastUpdated.astro
@@ -1,27 +1,27 @@
 ---
-let lasUpdatedDate: string;
+import { isProd } from '@/utils/misc';
+import { formatUpdatedDate } from '@/utils/date';
+
+let lastUpdatedDate: string;
 try {
-  const ghResponse = await fetch(
-    'https://api.github.com/repos/esafev/thoughts/branches/main'
-  );
-  const ghCommits = await ghResponse.json();
+  if (!isProd()) {
+    lastUpdatedDate = formatUpdatedDate(new Date());
+  } else {
+    const ghResponse = await fetch(
+      'https://api.github.com/repos/esafev/thoughts/branches/main'
+    );
+    const ghCommits = await ghResponse.json();
+    const lastCommitDate = ghCommits?.commit?.commit?.author?.date;
 
-  const lastCommitDate = ghCommits?.commit?.commit?.author?.date;
-  const date = new Date(lastCommitDate);
-  const dateTimeFormat = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'Europe/Berlin',
-    dateStyle: 'medium',
-    timeStyle: 'short'
-  });
-
-  lasUpdatedDate = `${dateTimeFormat.format(date)} [CET]`;
+    lastUpdatedDate = formatUpdatedDate(new Date(lastCommitDate));
+  }
 } catch {
-  lasUpdatedDate = 'unknown';
+  lastUpdatedDate = 'unknown';
 }
 
 ---
 
-<span>Last updated: {lasUpdatedDate}</span>
+<span>Last updated: {lastUpdatedDate}</span>
 
 
 <style>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,6 @@
-export function formatDate(date: Date | undefined, format: 'short' | 'long' = 'short'): string {
+type DateTimeFormat = 'long' | 'short';
+
+function formatDate(date?: Date, format: DateTimeFormat = 'short'): string {
   if (!date) return 'Unknown date';
 
   const options: Intl.DateTimeFormatOptions = {
@@ -9,3 +11,17 @@ export function formatDate(date: Date | undefined, format: 'short' | 'long' = 's
 
   return date.toLocaleDateString('en-US', options);
 }
+
+function formatUpdatedDate(date?: Date): string {
+  if (!date) return 'Unknown date';
+
+  const dateTimeFormat = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Berlin',
+    dateStyle: 'full',
+    timeStyle: 'short'
+  });
+
+  return `${dateTimeFormat.format(date)} [CET]`;
+}
+
+export { formatDate, formatUpdatedDate };

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,0 +1,5 @@
+function isProd(): boolean {
+  return import.meta.env.MODE === 'production';
+}
+
+export { isProd }


### PR DESCRIPTION
1. Use local data for the `LastUpdated` component instead of the GitHub API to avoid extra usage with every rebuild.
2. Move date formation to utils as well.